### PR TITLE
docs: fix spelling errors, template text, and broken links

### DIFF
--- a/.github/DISCUSSIONS.md
+++ b/.github/DISCUSSIONS.md
@@ -65,8 +65,8 @@ Format code properly, use clear titles, and include context.
 
 ## Quick Links
 
-- [Documentation](README.md)
+- [Documentation](../README.md)
 - [Bug Reports](../../issues)
-- [Contributing Guide](CONTRIBUTING.md)
+- [Contributing Guide](../CONTRIBUTING.md)
 
 Let's build an amazing community!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Steps:
 - Install and build: `npm install` then `npm run build`
 - Run tests (if any): `npm test`
 - Ensure TypeScript compiles: `npm run build`
-- Commit with clear messages and open a Pull Request against `main`.
+- Commit with clear messages and open a Pull Request against `develop`.
 
 Code style:
 

--- a/docs/dev/VISION.md
+++ b/docs/dev/VISION.md
@@ -1,4 +1,4 @@
-# Development Vision - vs-code extenstion to ... WinCC OA
+# Development Vision - vs-code extension to ... WinCC OA
 
 ## 🎯 Vision Statement
 
@@ -238,7 +238,7 @@
 
 ---
 
-**Last Updated**: Januar 5, 2026  
+**Last Updated**: January 5, 2026  
 **Vision Status**: Active Development  
 **Target Release**: v1.0.0 (Q1 2026)
 


### PR DESCRIPTION
## Summary
- Fixed spelling: "extenstion" → "extension", "Januar" → "January" in VISION.md
- Fixed CONTRIBUTING.md PR target branch: `main` → `develop` (matches GitFlow workflow)
- Fixed broken relative links in .github/DISCUSSIONS.md

Resolves part of winccoa-tools-pack/.github#73
